### PR TITLE
Set SameSite=Strict cookies

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -4,7 +4,7 @@ var xdebug = (function() {
 	{
 		var exp = new Date();
 		exp.setTime(exp.getTime() + (days * 24 * 60 * 60 * 1000));
-		document.cookie = name + "=" + value + "; expires=" + exp.toGMTString() + "; path=/";
+		document.cookie = name + "=" + value + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Strict";
 	}
 
 	// Get the content in a cookie


### PR DESCRIPTION
This is needed because newer browsers such as Firefox 76 are starting to require this. See also https://bugs.xdebug.org/1782