### PR TITLE
Set x-forwarded-for

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -177,19 +177,21 @@ function isValueInArray(arr, val)
 	return false;
 }
 
-// fix
 function addForwardedForHeader(e) {
-	e.requestHeaders.push({
-		name: "X-Forwarded-For", 
-		value: "192.168.1.29"
-	})
+	let ip = localStorage["xdebugConnectBackIP"];
+	if (ip) {
+		e.requestHeaders.push({	
+			name: "X-Forwarded-For", 
+			value: ip
+		})
+	}
 	return e;
 }
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
 	addForwardedForHeader,
 	{
-		urls: ["https://centos/*"]
+		urls: ["https://*/*"]
 	}, 
 	["blocking", "requestHeaders"]
 )

--- a/source/background.js
+++ b/source/background.js
@@ -176,3 +176,20 @@ function isValueInArray(arr, val)
 
 	return false;
 }
+
+// fix
+function addForwardedForHeader(e) {
+	e.requestHeaders.push({
+		name: "X-Forwarded-For", 
+		value: "192.168.1.29"
+	})
+	return e;
+}
+
+chrome.webRequest.onBeforeSendHeaders.addListener(
+	addForwardedForHeader,
+	{
+		urls: ["https://centos/*"]
+	}, 
+	["blocking", "requestHeaders"]
+)

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -6,7 +6,7 @@
 
 	"manifest_version": 2,
 	"minimum_chrome_version": "20",
-	"permissions": [ "tabs", "*://*/*" ],
+	"permissions": [ "tabs", "*://*/*", "webRequest", "webRequestBlocking" ],
 	"icons": {
 		"16": "images/icon--16.png",
 		"48": "images/icon--48.png",

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -3,7 +3,6 @@
 	"description": "Easy debugging, profiling and tracing extension for Xdebug",
 	"version": "1.0.6",
 	"author": "Brian Gilbert",
-
 	"manifest_version": 2,
 	"minimum_chrome_version": "20",
 	"permissions": [ "tabs", "*://*/*", "webRequest", "webRequestBlocking" ],

--- a/source/options.html
+++ b/source/options.html
@@ -58,6 +58,17 @@
 				<input type="text" id="profiletrigger" value="">
 				<button class="save-button">Save</button>
 			</p>
+
+			<h3>Connect Back IP</h3>
+			<p class="note">If you are coding in a remote environment such as using VS Code over SSH
+				and have <code>remote_connect_back</code> enabled, set the IP of your SSH server
+				that VS Code is hosted on. xdebug will connect back to that IP instead of
+				trying to connect back to this browser's computer's IP.
+			</p>
+			<p>
+				<input type="text" id="connectbackip" value="">
+				<button class="save-button">Save</button>
+			</p>
 			<footer id="footer">
 				<a href="https://github.com/briangilbert/xdebug-helper-for-firefox" class="contribute" target="_blank">
 					Feel free to submit ideas, bugs and pull request to our <span>Github project</span>

--- a/source/options.js
+++ b/source/options.js
@@ -3,6 +3,7 @@ function save_options()
 	localStorage["xdebugIdeKey"] = document.getElementById("idekey").value;
 	localStorage["xdebugTraceTrigger"] = document.getElementById("tracetrigger").value;
 	localStorage["xdebugProfileTrigger"] = document.getElementById("profiletrigger").value;
+	localStorage["xdebugConnectBackIP"] = document.getElementById("connectbackip").value;
 }
 
 function restore_options()
@@ -41,6 +42,13 @@ function restore_options()
 		$("#profiletrigger").val(profileTrigger);
 	} else {
 		$("#profiletrigger").val(null);
+	}
+
+	var connectBackIP = localStorage["xdebugConnectBackIP"];
+	if (connectBackIP !== null) {
+		$("#connectbackip").val(connectBackIP)
+	} else {
+		$("#connectbackip").val(null)
 	}
 }
 


### PR DESCRIPTION
Closes #16 

This allows you to set a connect back IP other than your browser, so you can use this in remote environments, such as when you are debugging on another machine, such as Remote SSH on VS Code. 