### PR TITLE
Set SameSite=Lax for the cookie to fix remote debugging after redirects like in OAuth flow

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -4,7 +4,7 @@ var xdebug = (function() {
 	{
 		var exp = new Date();
 		exp.setTime(exp.getTime() + (days * 24 * 60 * 60 * 1000));
-		document.cookie = name + "=" + value + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Strict";
+		document.cookie = name + "=" + value + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Lax";
 	}
 
 	// Get the content in a cookie


### PR DESCRIPTION
Fixes #23 and maybe #25 as well
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values