### PR TITLE
Make address bar icon visible in dark mode

### DIFF
--- a/source/images/bug-outline.svg
+++ b/source/images/bug-outline.svg
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <g transform="matrix(1.33404,0,0,1.33404,-4.00426,-4.00213)">
+    <style>
+        #bug-outline-fill { fill: black; }
+        
+        @media (prefers-color-scheme: dark) {
+            #bug-outline-fill { fill: white; }
+        }
+    </style>
+    <g id="bug-outline-fill" transform="matrix(1.33404,0,0,1.33404,-4.00426,-4.00213)">
         <path d="M20,8L17.19,8C16.74,7.2 16.12,6.5 15.37,6L17,4.41L15.59,3L13.42,5.17C12.96,5.06 12.5,5 12,5C11.5,5 11.05,5.06 10.59,5.17L8.41,3L7,4.41L8.62,6C7.87,6.5 7.26,7.21 6.81,8L4,8L4,10L6.09,10C6.03,10.33 6,10.66 6,11L6,12L4,12L4,14L6,14L6,15C6,15.34 6.03,15.67 6.09,16L4,16L4,18L6.81,18C8.47,20.87 12.14,21.84 15,20.18C15.91,19.66 16.67,18.9 17.19,18L20,18L20,16L17.91,16C17.97,15.67 18,15.34 18,15L18,14L20,14L20,12L18,12L18,11C18,10.66 17.97,10.33 17.91,10L20,10L20,8M16,15C16,17.194 14.194,19 12,19C9.806,19 8,17.194 8,15L8,11C8,8.806 9.806,7 12,7C14.194,7 16,8.806 16,11L16,15M14,10L14,12L10,12L10,10L14,10M10,14L14,14L14,16L10,16L10,14Z" style="fill-rule:nonzero;"/>
     </g>
 </svg>


### PR DESCRIPTION
## Issue 
In Firefox 149 Nightly (or Firefox 152 Stable, released 2026-06-17) the automatic address bar icon light and dark mode was disabled. Without this, the icon is currently rendered black, even in dark mode Firefox:

<img width="165" height="81" alt="grafik" src="https://github.com/user-attachments/assets/b52f91e4-2340-43d8-a910-8550e0c5b36d" />

## Solution
This PR fixes that by adding the recommended `prefers-color-scheme` CSS media query to the SVG styles.

<img width="165" height="81" alt="grafik" src="https://github.com/user-attachments/assets/d8f2fb22-672e-4ff7-b16a-d2e8441b0751" />

## Sources
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions#icons
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#default_icon
- https://github.com/mdn/webextensions-examples/blob/main/themed-icons/prefers-color-scheme-icon.svg
- https://bugzilla.mozilla.org/show_bug.cgi?id=2016509
- https://github.com/mozilla-firefox/firefox/commit/aeb4413e3d101e74f416b5d5853ca2adc726aa22
- [https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/149#changes_for_add-on_developers](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/149#changes_for_add-on_developers:~:text=will%20be%20deactivated%20in%20other%20Firefox%20editions%20from%20version%20152)

### Try it out:
- about:config → `extensions.webextensions.pageActionIconDarkModeFilter.enabled`